### PR TITLE
Use ENV to set MDS_URL

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,12 +36,12 @@ ENV['LOG_LEVEL'] ||= "info"
 ENV['TRUSTED_IP'] ||= "10.0.90.1"
 
 ENV["MDS_URL"] =
-  case ENV["API_URL"]
-  when "https://api.datacite.org" then "https://mds.datacite.org"
-  when "https://api.test.datacite.org" then "https://mds.test.datacite.org"
-  when "https://api.stage.datacite.org" then "https://mds.stage.datacite.org"
+  case Rails.env
+  when "production" then "https://mds.datacite.org"
+  when "test" then "https://mds.test.datacite.org"
+  when "stage" then "https://mds.stage.datacite.org"
+  when "development" then "https://mds.stage.datacite.org"
   end
-
 
 module Poodle
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,13 +35,7 @@ ENV['SITE_TITLE'] ||= "MDS API"
 ENV['LOG_LEVEL'] ||= "info"
 ENV['TRUSTED_IP'] ||= "10.0.90.1"
 
-ENV["MDS_URL"] =
-  case Rails.env
-  when "production" then "https://mds.datacite.org"
-  when "test" then "https://mds.test.datacite.org"
-  when "stage" then "https://mds.stage.datacite.org"
-  when "development" then "https://mds.stage.datacite.org"
-  end
+ENV["MDS_URL"] ||= Rails.env.production? ? "https://mds.datacite.org" : "https://mds.test.datacite.org"
 
 module Poodle
   class Application < Rails::Application

--- a/spec/requests/metadata_spec.rb
+++ b/spec/requests/metadata_spec.rb
@@ -41,7 +41,7 @@ describe "metadata", type: :request, vcr: true, order: :defined do
       put "/metadata/#{doi_id}", data, headers
 
       expect(last_response.status).to eq(201)
-      expect(last_response.header["Location"]).to eq("https://mds.stage.datacite.org/metadata/10.5072/ey2x-5w17")
+      expect(last_response.header["Location"]).to eq(ENV["MDS_URL"] + "/metadata/10.5072/ey2x-5w17")
       expect(last_response.body).to eq("OK (#{doi_id.upcase})")
     end
 


### PR DESCRIPTION
This fixes a case when the API_URL was actually different to one of these options.

## Approach
* Changes the way we set MDS_URL
* also updated additional test to also use this.

Related to https://github.com/datacite/poodle/issues/36