### PR TITLE
Replace the /sbin/setuser app bundle install line with the following …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /home/app/webapp/vendor/bundle && \
 WORKDIR /home/app/webapp
 RUN gem install rubygems-update -v 3.5.6 && \
     gem install bundler:2.5.6 && \
-    /sbin/setuser app bundle install --path vendor/bundle
+    su - app -c "bundle install --path vendor/bundle"
 
 # Run additional scripts during container startup (i.e. not at build time)
 WORKDIR /home/app/webapp


### PR DESCRIPTION
Replace the /`sbin/setuser` app `bundle install` line with the following to properly run `bundle install` as the app user:

## Purpose

error I was getting:

[call_build_and_push / build](https://github.com/datacite/poodle/actions/runs/11838356642/job/32987450028#step:7:2033)
buildx failed with: ERROR: failed to solve: process "/bin/sh -c gem install rubygems-update -v 3.5.6 &&     gem install bundler:2.5.6 &&     /sbin/setuser app bundle install --path vendor/bundle" did not complete successfully: exit code: 5


