### PR TITLE
Fix secret_key_base must exist

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,7 +53,7 @@ module Poodle
     config.api_only = true
 
     # secret_key_base is not used by Rails API, as there are no sessions
-    # config.secret_key_base = 'blipblapblup'
+    config.secret_key_base = 'blipblapblup'
 
     # configure caching
     config.cache_store = :mem_cache_store, ENV["MEMCACHE_SERVERS"], { namespace: ENV["APPLICATION"] }


### PR DESCRIPTION
This needs to exist for the application to boot. We do not use rails sessions so it's just set to a hardcoded value.

## Purpose
Fixes poodle

## Approach
By returning the original config of setting the secret_key_base

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
